### PR TITLE
Prevent flinch when player has less than 1 health

### DIFF
--- a/source/flinch.acs
+++ b/source/flinch.acs
@@ -16,6 +16,13 @@ int cumulative_flinch_pitch[MAX_PLAYERS];	// Total amount player's pitch has fli
 int cumulative_flinch_roll[MAX_PLAYERS];	// Total amount player's roll has flinched.
 int hit_timer[MAX_PLAYERS];					// Time of last flinch.
 
+// Check whether an actor is alive.
+//
+function bool IsAlive(int tid)
+{
+	return GetActorProperty(tid, APROP_Health) > 0;
+}
+
 // Absolute value of a fixed-point number.
 //
 function int FixedAbs(int a)
@@ -111,7 +118,7 @@ script "RecoverView" ENTER
 		hit_timer[i] = Timer();
 		SetActorRoll(0, 1.0);
 
-		while (true)
+		while (IsAlive(0))
 		{
 			cumulative_flinch_angle[i] = RecoverAxis(cumulative_flinch_angle[i], 0);
 			cumulative_flinch_pitch[i] = RecoverAxis(cumulative_flinch_pitch[i], 1);
@@ -147,7 +154,7 @@ function int GetFlinch(int min, int max, int base_flinch)
 script "PlayerFlinch" (void)
 {
 	int player_number = PlayerNumber();
-	if (player_number >= 0 && player_number < MAX_PLAYERS)
+	if (player_number >= 0 && player_number < MAX_PLAYERS && IsAlive(0))
 	{
 		int i = player_number;
 


### PR DESCRIPTION
This is to fix a bug where the flinch script was interfering with the death roll.
